### PR TITLE
Add debug step to CI workflow for checking Vercel secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Debug Secrets
+        run: |
+          echo "Checking if secrets are set..."
+          if [ -n "${{ secrets.VERCEL_TOKEN }}" ]; then
+            echo "VERCEL_TOKEN is set"
+          else
+            echo "VERCEL_TOKEN is not set"
+          fi
+          if [ -n "${{ secrets.VERCEL_ORG_ID }}" ]; then
+            echo "VERCEL_ORG_ID is set"
+          else
+            echo "VERCEL_ORG_ID is not set"
+          fi
+          if [ -n "${{ secrets.VERCEL_PROJECT_ID }}" ]; then
+            echo "VERCEL_PROJECT_ID is set"
+          else
+            echo "VERCEL_PROJECT_ID is not set"
+          fi
+
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v25
         with:


### PR DESCRIPTION
This pull request introduces a debugging step in the CI workflow to verify the presence of required secrets before deploying to Vercel.

### CI Workflow Improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R76): Added a "Debug Secrets" step to check if `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets are set, providing better visibility into potential configuration issues during deployment.