### PR TITLE
Fix education diploma year and update dark background color in Tailwind config

### DIFF
--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -27,7 +27,7 @@ const Education = () => {
             <p className="text-sm text-gray-400">
               Diploma | Computer Engineering
               <br />
-              2020 – 2022
+              2019 – 2022
             </p>
             {/* <p className="text-xs text-gray-500 mt-1">Grade: A</p> */}
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -68,7 +68,7 @@ module.exports = {
         },
         background: {
           light: '#F9FAFB', // Gray 50
-          dark: '#111827', // Gray 900
+          dark: '#050608', // Changed to the requested color
         },
         text: {
           light: {


### PR DESCRIPTION
This pull request includes a minor update to the `Education` component in `src/components/Education.jsx`. The change corrects the diploma duration from "2020 – 2022" to "2019 – 2022" to accurately reflect the timeline.